### PR TITLE
SmAxisDisplayKit Improvements

### DIFF
--- a/lib/SmallChange/nodekits/SmAxisDisplayKit.cpp
+++ b/lib/SmallChange/nodekits/SmAxisDisplayKit.cpp
@@ -80,6 +80,17 @@
 */
 
 /*!
+  \var SoMFBool SmAxisDisplayKit::drawAsLines
+
+  Specifies whether arrows should be drawn as lines or as cylinders.
+  Cylinders may look better but lines are always drawn with the same width
+  You can use the drawestyle (SoDrawStyle) catalog entry to change the width of
+  the lines.
+
+  Default value is FALSE.
+*/
+
+/*!
   \var SoMFString SmAxisDisplayKit::annotations
 
   Specifies annotation for each axis. The annotation will be rendered
@@ -154,6 +165,7 @@ SmAxisDisplayKit::SmAxisDisplayKit(void)
   SO_KIT_ADD_FIELD(axes, (0.0f, 0.0f, 0.0f));
   SO_KIT_ADD_FIELD(colors, (1.0f, 1.0f, 1.0f));
   SO_KIT_ADD_FIELD(enableArrows, (TRUE));
+  SO_KIT_ADD_FIELD(drawAsLines, (FALSE));
   SO_KIT_ADD_FIELD(annotations, (""));
   SO_KIT_ADD_FIELD(headlight, (TRUE));
 
@@ -183,7 +195,7 @@ SmAxisDisplayKit::SmAxisDisplayKit(void)
   vpr->clearDepthBuffer = TRUE;
 
   SoDrawStyle *drawstyle = (SoDrawStyle *)this->getAnyPart("drawstyle", TRUE);
-  drawstyle->lineWidth = 2;
+  drawstyle->lineWidth = 1;
 
   SoShapeHints * sh = (SoShapeHints*) this->getAnyPart("shapehints", TRUE);
   sh->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
@@ -379,28 +391,31 @@ SmAxisDisplayKitP::oneshot_cb(void * closure, SoSensor * s)
 
     // Vector
     if (!linesep) { // Reuse linesep for all axes
-#if 0 // boring lines :)
-      linesep = new SoSeparator;
-      SoCoordinate3 *coord = new SoCoordinate3;
-      SoLineSet *ls = new SoLineSet;
+    	linesep = new SoSeparator;
+		if (PUBLIC(thisp)->drawAsLines.getValue() == TRUE) {
+		  // boring lines :)
+		  SoCoordinate3 *coord = new SoCoordinate3;
+		  SoLineSet *ls = new SoLineSet;
 
-      coord->point.set1Value(0, 0.0f, 0.0f, 0.0f);
-      coord->point.set1Value(1, 0.0f, 1.0f, 0.0f);
-      ls->numVertices.setValue(2);
+		  coord->point.set1Value(0, 0.0f, 0.0f, 0.0f);
+		  coord->point.set1Value(1, 0.0f, 1.0f, 0.0f);
+		  ls->numVertices.setValue(2);
 
-      linesep->addChild(coord);
-      linesep->addChild(ls);
-#else // better looking cylinders
-      linesep = new SoSeparator;
-      SoCylinder * cyl = new SoCylinder;
-      cyl->radius = 0.02f;
-      cyl->height = 1.0f;
-      SoTranslation * t = new SoTranslation;
-      t->translation = SbVec3f(0.0f, 0.5f, 0.0f);      
-      linesep->addChild(t);
-      linesep->addChild(cyl);
-#endif // cylinders
+		  linesep->addChild(coord);
+		  linesep->addChild(ls);
+		}
+		else {
+		  // better looking cylinders
+		  SoCylinder * cyl = new SoCylinder;
+		  cyl->radius = 0.02f;
+		  cyl->height = 1.0f;
+		  SoTranslation * t = new SoTranslation;
+		  t->translation = SbVec3f(0.0f, 0.5f, 0.0f);
+		  linesep->addChild(t);
+		  linesep->addChild(cyl);
+		}
     }
+
     axissep->addChild(axiscol);
     axissep->addChild(axistrans);
     axissep->addChild(linesep);

--- a/lib/SmallChange/nodekits/SmAxisDisplayKit.cpp
+++ b/lib/SmallChange/nodekits/SmAxisDisplayKit.cpp
@@ -180,7 +180,8 @@ SmAxisDisplayKit::SmAxisDisplayKit(void)
   SO_KIT_ADD_CATALOG_ENTRY(viewportRegion, ViewportRegion, FALSE, topSeparator, drawstyle, FALSE);
   SO_KIT_ADD_CATALOG_ENTRY(drawstyle, SoDrawStyle, FALSE, topSeparator, shapehints, FALSE);
   SO_KIT_ADD_CATALOG_ENTRY(shapehints, SoShapeHints, FALSE, topSeparator, headlightNode, FALSE);
-  SO_KIT_ADD_CATALOG_ENTRY(headlightNode, SmHeadlight, FALSE, topSeparator, axessep, TRUE);
+  SO_KIT_ADD_CATALOG_ENTRY(headlightNode, SmHeadlight, FALSE, topSeparator, font, TRUE);
+  SO_KIT_ADD_CATALOG_ENTRY(font, SoFont, FALSE, topSeparator, axessep, TRUE);
   SO_KIT_ADD_CATALOG_ENTRY(axessep, SoSeparator, FALSE, topSeparator, "", FALSE);
 
   SO_KIT_INIT_INSTANCE();

--- a/lib/SmallChange/nodekits/SmAxisDisplayKit.h
+++ b/lib/SmallChange/nodekits/SmAxisDisplayKit.h
@@ -57,6 +57,7 @@ class SMALLCHANGE_DLL_API SmAxisDisplayKit : public SoBaseKit
   SO_KIT_CATALOG_ENTRY_HEADER(shapehints);
   SO_KIT_CATALOG_ENTRY_HEADER(headlightNode);
   SO_KIT_CATALOG_ENTRY_HEADER(axessep);
+  SO_KIT_CATALOG_ENTRY_HEADER(font);
 
 public:
   SoSFRotation orientation;

--- a/lib/SmallChange/nodekits/SmAxisDisplayKit.h
+++ b/lib/SmallChange/nodekits/SmAxisDisplayKit.h
@@ -63,6 +63,7 @@ public:
   SoMFVec3f axes;
   SoMFColor colors;
   SoMFBool enableArrows;
+  SoSFBool drawAsLines;
   SoMFString annotations;
   SoSFBool headlight;
 


### PR DESCRIPTION
This merge request improves the "styling" capabilities of `SmAxisDisplayKit`.

1. now it is possible to select the style for drawing the arrow lines using the drawAsLines field - it is possible to switch between simple lines and cones. Using lines improves the vivibility in small windows because it is always painted witgh a fixed line with.
2. a font catalog entry has been added that allows the user to change the font style and size of the axis annotations